### PR TITLE
Change alert element, Bump to v0.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mindscreen/formvalidation",
-    "version": "0.1.4",
+    "version": "0.1.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mindscreen/formvalidation",
-            "version": "0.1.4",
+            "version": "0.1.6",
             "license": "MIT",
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mindscreen/formvalidation",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "license": "MIT",
     "description": "Provides means for an accessible form validation",
     "repository": "https://github.com/mindscreen/accessible-formvalidation",

--- a/src/validation/error-handler.ts
+++ b/src/validation/error-handler.ts
@@ -378,14 +378,13 @@ export class ErrorHandler implements ErrorHandlerInterface<IErrorHandlerOptions>
     private insertErrorNode(error: IErrorInfo, node: HTMLElement) {
         const validationPlacement = error.inputGroup
             .getAttribute(this.options.selectors.validationPlacementAttribute);
-        const liveRegion = document.createElement('div');
-        liveRegion.setAttribute('role', 'alert');
+        const errorNodeWrapper = document.createElement('div');
         if (error.inputElement?.type === 'radio' && validationPlacement) {
-            insertPositional(error.inputGroup, liveRegion, validationPlacement);
+            insertPositional(error.inputGroup, errorNodeWrapper, validationPlacement);
         } else {
-            insertPositional(error.inputGroup, liveRegion, 'before .form-text, in this');
+            insertPositional(error.inputGroup, errorNodeWrapper, 'before .form-text, in this');
         }
-        liveRegion.append(node);
+        errorNodeWrapper.append(node);
     }
 
     /**
@@ -456,6 +455,7 @@ export class ErrorHandler implements ErrorHandlerInterface<IErrorHandlerOptions>
             errorContainer.classList.remove(this.options.classNames.errorListContainer + '--form-submitted');
         } else {
             errorContainer.classList.add(this.options.classNames.errorListContainer + '--form-submitted');
+            errorContainer.setAttribute('role', 'alert');
             errorContainer.querySelector('h2').focus();
         }
     }


### PR DESCRIPTION
- Remove the role=alert from error message of each input field
- Instead set role=alert on the summary error info above the form field, since this element also receives focus. Also, this reduces the output of screenreaders which was partially confusing information.